### PR TITLE
Remove the DRF < 3.2 support

### DIFF
--- a/rest_framework_jwt/compat.py
+++ b/rest_framework_jwt/compat.py
@@ -154,10 +154,4 @@ def get_custom_user_identifier(user):
 
 
 def get_request_data(request):
-    if getattr(request, 'data', None):
-        data = request.data
-    else:
-        # DRF < 3.2
-        data = request.DATA
-
-    return data
+    return getattr(request, 'data', None)


### PR DESCRIPTION
This is basically how the new version gets the data.

The None data will be thrown to the serializer, and is_valid() will say False with correct error message.

Verified the request with empty body before this change will trigger the 500 we got today, and after this change, I got 400 correctly:

{
	"password": [
		"This field is required."
	],
	"email": [
		"This field is required."
	]
}